### PR TITLE
Add admin pages and language toggle

### DIFF
--- a/ReframeWebsiteUpdate/client/src/App.tsx
+++ b/ReframeWebsiteUpdate/client/src/App.tsx
@@ -3,13 +3,35 @@ import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { AuthProvider } from "./lib/auth";
+import { LangProvider } from "./lib/lang";
 import Home from "@/pages/home";
+import About from "@/pages/about";
+import Services from "@/pages/services";
+import TechnicalConsultation from "@/pages/services/technical-consultation";
+import EmpowermentHub from "@/pages/services/empowerment-hub";
+import MentalHealthLab from "@/pages/services/mental-health-lab";
+import Translation from "@/pages/services/translation";
+import Team from "@/pages/team";
+import Admin from "@/pages/admin";
+import Contact from "@/pages/contact";
+import Login from "@/pages/login";
 import NotFound from "@/pages/not-found";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Home} />
+      <Route path="/about" component={About} />
+      <Route path="/services" component={Services} />
+      <Route path="/services/technical-consultation" component={TechnicalConsultation} />
+      <Route path="/services/empowerment-hub" component={EmpowermentHub} />
+      <Route path="/services/mental-health-lab" component={MentalHealthLab} />
+      <Route path="/services/translation" component={Translation} />
+      <Route path="/contact" component={Contact} />
+      <Route path="/login" component={Login} />
+      <Route path="/team" component={Team} />
+      <Route path="/admin" component={Admin} />
       <Route component={NotFound} />
     </Switch>
   );
@@ -18,10 +40,14 @@ function Router() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <Toaster />
-        <Router />
-      </TooltipProvider>
+      <AuthProvider>
+        <LangProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Router />
+          </TooltipProvider>
+        </LangProvider>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/ReframeWebsiteUpdate/client/src/components/calendar-section.tsx
+++ b/ReframeWebsiteUpdate/client/src/components/calendar-section.tsx
@@ -5,8 +5,7 @@ import type { Event } from "@shared/schema";
 
 export default function CalendarSection() {
   const [currentDate, setCurrentDate] = useState(new Date());
-  const [showCollaborationModal, setShowCollaborationModal] = useState(false);
-  
+
   const { data: events = [] } = useQuery<Event[]>({
     queryKey: ['/api/events/upcoming'],
   });
@@ -146,8 +145,8 @@ export default function CalendarSection() {
               <div className="text-center">
                 <p className="text-xl font-semibold mb-4">Would you like to collaborate with us?</p>
                 <div className="flex gap-4 justify-center">
-                  <button 
-                    onClick={() => setShowCollaborationModal(true)}
+                  <button
+                    onClick={() => window.dispatchEvent(new Event('showCollaborationModal'))}
                     className="bg-white text-secondary px-6 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors"
                   >
                     Yes, Let's Collaborate
@@ -162,64 +161,7 @@ export default function CalendarSection() {
         </div>
       </div>
 
-      {/* Pass modal state to global context or handle it here */}
-      {showCollaborationModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-            <div className="p-8">
-              <div className="flex justify-between items-center mb-6">
-                <h2 className="text-2xl font-bold text-neutral">Mental Health Lab Collaboration</h2>
-                <button 
-                  onClick={() => setShowCollaborationModal(false)}
-                  className="text-gray-400 hover:text-gray-600"
-                >
-                  <i className="fas fa-times text-xl"></i>
-                </button>
-              </div>
-              
-              <p className="text-gray-600 mb-8">
-                We're excited about the possibility of collaborating with you! Please fill out the form below and let us know how we can work together.
-              </p>
-              
-              <form className="space-y-6">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-neutral mb-2">Name *</label>
-                    <input type="text" required className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-secondary focus:border-transparent" />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-neutral mb-2">Email *</label>
-                    <input type="email" required className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-secondary focus:border-transparent" />
-                  </div>
-                </div>
-                
-                <div>
-                  <label className="block text-sm font-medium text-neutral mb-2">How can we collaborate together? *</label>
-                  <textarea 
-                    required 
-                    rows={5} 
-                    placeholder="Please let us know how we can collaborate together..." 
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-secondary focus:border-transparent resize-none"
-                  ></textarea>
-                </div>
-                
-                <div className="flex gap-4">
-                  <button type="submit" className="bg-secondary text-white px-6 py-3 rounded-lg font-semibold hover:bg-accent transition-colors flex-1">
-                    Submit Collaboration Request
-                  </button>
-                  <button 
-                    type="button" 
-                    onClick={() => setShowCollaborationModal(false)}
-                    className="border border-gray-300 text-neutral px-6 py-3 rounded-lg font-semibold hover:bg-gray-50 transition-colors"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* The collaboration modal is handled globally */}
     </section>
   );
 }

--- a/ReframeWebsiteUpdate/client/src/components/hero-section.tsx
+++ b/ReframeWebsiteUpdate/client/src/components/hero-section.tsx
@@ -1,13 +1,31 @@
+import { useEffect, useState } from "react";
 import { Link } from "wouter";
 
+import img1 from "../../../1000373231.jpg";
+import img2 from "../../../1000373664.jpg";
+import img3 from "../../../1000374302.jpg";
+import img4 from "../../../1000374553.jpg";
+import img5 from "../../../1000717336.jpg";
+
+const images = [img1, img2, img3, img4, img5];
+
 export default function HeroSection() {
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCurrent((c) => (c + 1) % images.length);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+
   return (
-    <section className="relative bg-gradient-to-br from-primary via-secondary to-accent text-white overflow-hidden">
-      <div className="absolute inset-0 bg-black bg-opacity-20"></div>
-      <div className="absolute inset-0 bg-cover bg-center bg-no-repeat" 
-           style={{backgroundImage: "url('https://images.unsplash.com/photo-1521791136064-7986c2920216?ixlib=rb-4.0.3&auto=format&fit=crop&w=1920&h=1080')"}}></div>
-      <div className="absolute inset-0 hero-overlay"></div>
-      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
+    <section
+      className="relative text-white overflow-hidden h-[500px] md:h-[650px] bg-cover bg-center"
+      style={{ backgroundImage: `url(${images[current]})` }}
+    >
+      <div className="absolute inset-0 bg-gradient-to-br from-primary via-secondary to-accent opacity-70"></div>
+      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
         <div className="max-w-3xl animate-slide-up">
           <h1 className="text-4xl lg:text-6xl font-bold mb-6">
             Unlocking the Innate Potential and Resilience Within Each Person and Group
@@ -16,13 +34,13 @@ export default function HeroSection() {
             Professional mental health services and training programs designed for the Middle East, delivered in Arabic with cultural relevance.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
-            <button 
+            <button
               onClick={() => document.querySelector('.mental-health-lab')?.scrollIntoView({ behavior: 'smooth' })}
               className="bg-white text-primary px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-100 transition-colors text-center"
             >
               Explore Mental Health Lab
             </button>
-            <button 
+            <button
               onClick={() => document.querySelector('.services-section')?.scrollIntoView({ behavior: 'smooth' })}
               className="border-2 border-white text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-white hover:text-primary transition-colors text-center"
             >

--- a/ReframeWebsiteUpdate/client/src/components/navigation.tsx
+++ b/ReframeWebsiteUpdate/client/src/components/navigation.tsx
@@ -1,9 +1,13 @@
 import { useState } from "react";
 import { Link } from "wouter";
+import { useAuth } from "@/lib/auth";
+import { useLang } from "@/lib/lang";
 
 export default function Navigation() {
   const [isServiceDropdownOpen, setIsServiceDropdownOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const { isAdmin } = useAuth();
+  const { toggle } = useLang();
 
   return (
     <nav className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-50">
@@ -28,16 +32,18 @@ export default function Navigation() {
               </Link>
               
               {/* Services Dropdown */}
-              <div 
-                className="relative"
-                onMouseEnter={() => setIsServiceDropdownOpen(true)}
-                onMouseLeave={() => setIsServiceDropdownOpen(false)}
-              >
-                <button className="text-neutral hover:text-primary px-3 py-2 text-sm font-medium transition-colors flex items-center">
+              <div className="relative">
+                <button
+                  onClick={() => setIsServiceDropdownOpen(!isServiceDropdownOpen)}
+                  className="text-neutral hover:text-primary px-3 py-2 text-sm font-medium transition-colors flex items-center"
+                >
                   Services <i className="fas fa-chevron-down ml-1 text-xs"></i>
                 </button>
                 {isServiceDropdownOpen && (
-                  <div className="absolute left-0 mt-2 w-80 bg-white rounded-lg shadow-lg border border-gray-200 z-20">
+                  <div
+                    className="absolute left-0 mt-2 w-80 bg-white rounded-lg shadow-lg border border-gray-200 z-20"
+                    onMouseLeave={() => setIsServiceDropdownOpen(false)}
+                  >
                     <div className="py-2">
                       <Link href="/services/technical-consultation" className="block px-4 py-3 text-sm text-neutral hover:bg-gray-50 hover:text-primary border-b border-gray-100">
                         <div className="font-medium">Technical Consultation & Support</div>
@@ -66,7 +72,12 @@ export default function Navigation() {
               <Link href="/login" className="text-neutral hover:text-primary px-3 py-2 text-sm font-medium transition-colors">
                 Login
               </Link>
-              <button className="bg-secondary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-accent transition-colors">
+              {isAdmin && (
+                <Link href="/admin" className="text-neutral hover:text-primary px-3 py-2 text-sm font-medium transition-colors">
+                  Add Employee
+                </Link>
+              )}
+              <button className="bg-secondary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-accent transition-colors" onClick={toggle}>
                 AR-Eng
               </button>
             </div>
@@ -113,6 +124,11 @@ export default function Navigation() {
               <Link href="/login" className="block px-3 py-2 text-base font-medium text-neutral hover:text-primary">
                 Login
               </Link>
+              {isAdmin && (
+                <Link href="/admin" className="block px-3 py-2 text-base font-medium text-neutral hover:text-primary">
+                  Add Employee
+                </Link>
+              )}
             </div>
           </div>
         )}

--- a/ReframeWebsiteUpdate/client/src/components/reframe-hub.tsx
+++ b/ReframeWebsiteUpdate/client/src/components/reframe-hub.tsx
@@ -1,0 +1,37 @@
+export default function ReframeHubSection() {
+  return (
+    <section className="py-16 bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+          <div>
+            <h2 className="text-3xl lg:text-4xl font-bold text-neutral mb-6">Reframe Hub</h2>
+            <p className="text-lg text-gray-600 mb-6">
+              A professional space designed for meetings, conferences, and workshops. Our modern facilities provide the perfect environment for learning, collaboration, and professional development.
+            </p>
+            <div className="space-y-4 mb-8">
+              <div className="flex items-center">
+                <i className="fas fa-check-circle text-secondary mr-3"></i>
+                <span className="text-gray-700">Modern conference facilities</span>
+              </div>
+              <div className="flex items-center">
+                <i className="fas fa-check-circle text-secondary mr-3"></i>
+                <span className="text-gray-700">Professional audio-visual equipment</span>
+              </div>
+              <div className="flex items-center">
+                <i className="fas fa-check-circle text-secondary mr-3"></i>
+                <span className="text-gray-700">Flexible seating arrangements</span>
+              </div>
+              <div className="flex items-center">
+                <i className="fas fa-check-circle text-secondary mr-3"></i>
+                <span className="text-gray-700">Convenient location</span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <img src="https://images.unsplash.com/photo-1560472354-b33ff0c44a43?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=600" alt="Modern conference room" className="rounded-2xl shadow-lg w-full h-auto" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/lib/auth.tsx
+++ b/ReframeWebsiteUpdate/client/src/lib/auth.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface AuthContextValue {
+  isAdmin: boolean;
+  login: (username: string, password: string) => boolean;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  isAdmin: false,
+  login: () => false,
+  logout: () => {},
+});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    setIsAdmin(localStorage.getItem("isAdmin") === "true");
+  }, []);
+
+  const login = (username: string, password: string) => {
+    if (username === "admin" && password === "password") {
+      localStorage.setItem("isAdmin", "true");
+      setIsAdmin(true);
+      return true;
+    }
+    return false;
+  };
+
+  const logout = () => {
+    localStorage.removeItem("isAdmin");
+    setIsAdmin(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ isAdmin, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/ReframeWebsiteUpdate/client/src/lib/lang.tsx
+++ b/ReframeWebsiteUpdate/client/src/lib/lang.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface LangContextValue {
+  lang: "en" | "ar";
+  toggle: () => void;
+}
+
+const LangContext = createContext<LangContextValue>({
+  lang: "en",
+  toggle: () => {},
+});
+
+export function LangProvider({ children }: { children: React.ReactNode }) {
+  const [lang, setLang] = useState<"en" | "ar">(
+    (localStorage.getItem("lang") as "en" | "ar") || "en",
+  );
+
+  useEffect(() => {
+    localStorage.setItem("lang", lang);
+    document.documentElement.lang = lang;
+    document.documentElement.dir = lang === "ar" ? "rtl" : "ltr";
+  }, [lang]);
+
+  const toggle = () => setLang((l) => (l === "en" ? "ar" : "en"));
+
+  return (
+    <LangContext.Provider value={{ lang, toggle }}>{children}</LangContext.Provider>
+  );
+}
+
+export function useLang() {
+  return useContext(LangContext);
+}

--- a/ReframeWebsiteUpdate/client/src/pages/about.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/about.tsx
@@ -1,0 +1,30 @@
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import NewsletterSection from "@/components/newsletter-section";
+
+export default function About() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <section className="py-16 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-8">
+          <div>
+            <h1 className="text-3xl lg:text-4xl font-bold text-neutral mb-4">About Us</h1>
+            <p className="text-gray-700">We are a team of mental health professionals dedicated to providing culturally relevant services across the Middle East.</p>
+          </div>
+          <div>
+            <h2 className="text-2xl font-semibold mb-2">Our Core Values</h2>
+            <ul className="list-disc list-inside text-gray-700 space-y-1">
+              <li>Integrity</li>
+              <li>Compassion</li>
+              <li>Collaboration</li>
+              <li>Innovation</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+      <NewsletterSection />
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/pages/admin.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/admin.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import { useAuth } from "@/lib/auth";
+
+interface Employee {
+  name: string;
+  title: string;
+  photo?: string;
+}
+
+export default function Admin() {
+  const { isAdmin } = useAuth();
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [name, setName] = useState("");
+  const [title, setTitle] = useState("");
+  const [photo, setPhoto] = useState("");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("employees");
+    if (stored) setEmployees(JSON.parse(stored));
+  }, []);
+
+  const addEmployee = () => {
+    const updated = [...employees, { name, title, photo }];
+    setEmployees(updated);
+    localStorage.setItem("employees", JSON.stringify(updated));
+    setName("");
+    setTitle("");
+    setPhoto("");
+  };
+
+  if (!isAdmin) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <p className="text-lg">Access denied</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <section className="py-16">
+        <div className="max-w-md mx-auto px-4 space-y-4">
+          <h1 className="text-2xl font-bold text-neutral">Add Employee</h1>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name"
+            className="w-full border rounded px-3 py-2"
+          />
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Title"
+            className="w-full border rounded px-3 py-2"
+          />
+          <input
+            value={photo}
+            onChange={(e) => setPhoto(e.target.value)}
+            placeholder="Photo URL"
+            className="w-full border rounded px-3 py-2"
+          />
+          <button onClick={addEmployee} className="bg-secondary text-white px-4 py-2 rounded">
+            Add Employee
+          </button>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/pages/contact.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/contact.tsx
@@ -1,0 +1,22 @@
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+
+export default function Contact() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <section className="py-16">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+          <h1 className="text-3xl font-bold text-neutral">Contact Us</h1>
+          <p className="text-gray-700">Reach out for collaboration or inquiries.</p>
+          <div className="space-y-2 text-gray-700">
+            <p><i className="fas fa-map-marker-alt mr-2"></i>Beirut, Lebanon</p>
+            <p><i className="fas fa-phone mr-2"></i>+961 1 234 567</p>
+            <p><i className="fas fa-envelope mr-2"></i>info@reframemhs.com</p>
+          </div>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/pages/home.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/home.tsx
@@ -20,44 +20,7 @@ export default function Home() {
       <MilestonesSection />
       <PartnersCarousel />
       <ServicesOverview />
-      <div className="py-16 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-            <div>
-              <h2 className="text-3xl lg:text-4xl font-bold text-neutral mb-6">Reframe Hub</h2>
-              <p className="text-lg text-gray-600 mb-6">
-                A professional space designed for meetings, conferences, and workshops. Our modern facilities provide the perfect environment for learning, collaboration, and professional development.
-              </p>
-              <div className="space-y-4 mb-8">
-                <div className="flex items-center">
-                  <i className="fas fa-check-circle text-secondary mr-3"></i>
-                  <span className="text-gray-700">Modern conference facilities</span>
-                </div>
-                <div className="flex items-center">
-                  <i className="fas fa-check-circle text-secondary mr-3"></i>
-                  <span className="text-gray-700">Professional audio-visual equipment</span>
-                </div>
-                <div className="flex items-center">
-                  <i className="fas fa-check-circle text-secondary mr-3"></i>
-                  <span className="text-gray-700">Flexible seating arrangements</span>
-                </div>
-                <div className="flex items-center">
-                  <i className="fas fa-check-circle text-secondary mr-3"></i>
-                  <span className="text-gray-700">Convenient location</span>
-                </div>
-              </div>
-              <button className="bg-secondary text-white px-6 py-3 rounded-lg font-semibold hover:bg-accent transition-colors">
-                Learn More About Our Hub
-              </button>
-            </div>
-            <div>
-              <img src="https://images.unsplash.com/photo-1560472354-b33ff0c44a43?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=600" 
-                   alt="Modern conference room with professional setup" 
-                   className="rounded-2xl shadow-lg w-full h-auto" />
-            </div>
-          </div>
-        </div>
-      </div>
+      {/* Reframe Hub moved to Services section */}
       <TestimonialsSection />
       <NewsletterSection />
       <Footer />

--- a/ReframeWebsiteUpdate/client/src/pages/login.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/login.tsx
@@ -1,0 +1,56 @@
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import { useState } from "react";
+import { useAuth } from "@/lib/auth";
+import { useLocation } from "wouter";
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const { login } = useAuth();
+  const [, navigate] = useLocation();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (login(email, password)) {
+      navigate("/admin");
+    } else {
+      alert("Invalid credentials");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <section className="py-16">
+        <div className="max-w-md mx-auto px-4 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold text-neutral mb-6">Login</h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Email</label>
+              <input
+                type="email"
+                className="w-full px-4 py-2 border rounded"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Password</label>
+              <input
+                type="password"
+                className="w-full px-4 py-2 border rounded"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+            <button type="submit" className="bg-secondary text-white px-6 py-2 rounded">Login</button>
+          </form>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/pages/services/empowerment-hub.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/services/empowerment-hub.tsx
@@ -1,0 +1,19 @@
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import ReframeHubSection from "@/components/reframe-hub";
+
+export default function EmpowermentHub() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <section className="py-16">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+          <h1 className="text-3xl font-bold text-neutral">Empowerment Hub & Training</h1>
+          <p className="text-gray-700">Long-term and short-term training opportunities designed for professionals.</p>
+        </div>
+      </section>
+      <ReframeHubSection />
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/pages/services/index.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/services/index.tsx
@@ -1,0 +1,13 @@
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import ServicesOverview from "@/components/services-overview";
+
+export default function Services() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <ServicesOverview />
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/pages/services/mental-health-lab.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/services/mental-health-lab.tsx
@@ -1,0 +1,25 @@
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import CollaborationModal from "@/components/collaboration-modal";
+
+export default function MentalHealthLab() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <section className="py-16">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+          <h1 className="text-3xl font-bold text-neutral">Mental Health Lab</h1>
+          <p className="text-gray-700">Learn more about our research projects and download related documents.</p>
+          <button
+            onClick={() => window.dispatchEvent(new Event('showCollaborationModal'))}
+            className="bg-secondary text-white px-6 py-3 rounded-lg font-semibold"
+          >
+            Collaborate With Us
+          </button>
+        </div>
+      </section>
+      <CollaborationModal />
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/pages/services/technical-consultation.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/services/technical-consultation.tsx
@@ -1,0 +1,17 @@
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+
+export default function TechnicalConsultation() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <section className="py-16">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+          <h1 className="text-3xl font-bold text-neutral">Technical Consultation & Support</h1>
+          <p className="text-gray-700">Professional guidance for corporations and NGOs implementing mental health programs and policies.</p>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/pages/services/translation.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/services/translation.tsx
@@ -1,0 +1,17 @@
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+
+export default function Translation() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <section className="py-16">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+          <h1 className="text-3xl font-bold text-neutral">Professional Translation</h1>
+          <p className="text-gray-700">This service is currently under construction.</p>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/client/src/pages/team.tsx
+++ b/ReframeWebsiteUpdate/client/src/pages/team.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+
+interface Employee {
+  name: string;
+  title: string;
+  photo?: string;
+}
+
+export default function Team() {
+  const [employees, setEmployees] = useState<Employee[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("employees");
+    if (stored) setEmployees(JSON.parse(stored));
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <section className="py-16">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold text-neutral mb-8">Our Team</h1>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8">
+            {employees.map((emp, i) => (
+              <div key={i} className="bg-white rounded-lg shadow p-4 text-center">
+                {emp.photo && (
+                  <img
+                    src={emp.photo}
+                    alt={emp.name}
+                    className="w-32 h-32 object-cover rounded-full mx-auto mb-4"
+                  />
+                )}
+                <h3 className="font-semibold text-lg">{emp.name}</h3>
+                <p className="text-sm text-gray-600">{emp.title}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}

--- a/ReframeWebsiteUpdate/server/storage.ts
+++ b/ReframeWebsiteUpdate/server/storage.ts
@@ -140,11 +140,15 @@ export class MemStorage implements IStorage {
 
   async createEvent(insertEvent: InsertEvent): Promise<Event> {
     const id = this.currentId++;
-    const event: Event = { 
-      ...insertEvent, 
-      id, 
+    const event: Event = {
+      id,
+      title: insertEvent.title,
+      date: new Date(insertEvent.date),
+      type: insertEvent.type,
+      time: insertEvent.time ?? null,
+      description: insertEvent.description ?? null,
+      registrationUrl: insertEvent.registrationUrl ?? null,
       createdAt: new Date(),
-      date: new Date(insertEvent.date)
     };
     this.events.set(id, event);
     return event;
@@ -180,7 +184,14 @@ export class MemStorage implements IStorage {
 
   async createMilestone(insertMilestone: InsertMilestone): Promise<Milestone> {
     const id = this.currentId++;
-    const milestone: Milestone = { ...insertMilestone, id };
+    const milestone: Milestone = {
+      id,
+      title: insertMilestone.title,
+      value: insertMilestone.value,
+      description: insertMilestone.description ?? null,
+      order: insertMilestone.order,
+      isActive: insertMilestone.isActive ?? true,
+    };
     this.milestones.set(id, milestone);
     return milestone;
   }
@@ -205,7 +216,14 @@ export class MemStorage implements IStorage {
 
   async createPartner(insertPartner: InsertPartner): Promise<Partner> {
     const id = this.currentId++;
-    const partner: Partner = { ...insertPartner, id };
+    const partner: Partner = {
+      id,
+      name: insertPartner.name,
+      type: insertPartner.type,
+      description: insertPartner.description ?? null,
+      logoUrl: insertPartner.logoUrl ?? null,
+      isActive: insertPartner.isActive ?? true,
+    };
     this.partners.set(id, partner);
     return partner;
   }
@@ -227,11 +245,17 @@ export class MemStorage implements IStorage {
 
   async createCollaborationRequest(insertRequest: InsertCollaborationRequest): Promise<CollaborationRequest> {
     const id = this.currentId++;
-    const request: CollaborationRequest = { 
-      ...insertRequest, 
-      id, 
+    const request: CollaborationRequest = {
+      id,
+      name: insertRequest.name,
+      email: insertRequest.email,
+      phone: insertRequest.phone ?? null,
+      country: insertRequest.country ?? null,
+      organization: insertRequest.organization ?? null,
+      position: insertRequest.position ?? null,
+      message: insertRequest.message,
       status: "pending",
-      createdAt: new Date()
+      createdAt: new Date(),
     };
     this.collaborationRequests.set(id, request);
     return request;

--- a/ReframeWebsiteUpdate/server/vite.ts
+++ b/ReframeWebsiteUpdate/server/vite.ts
@@ -20,7 +20,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: any = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,


### PR DESCRIPTION
## Summary
- implement language toggle with AR-Eng button
- add simple auth context and admin login
- provide admin page to add employees and a public team page
- fix Services dropdown behavior and remove Reframe Hub from home
- update server storage typings

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68670cb5e5288321bdf375dc85790853